### PR TITLE
Sequence names now fully displayed. Target positions now output.

### DIFF
--- a/mosaic.h
+++ b/mosaic.h
@@ -9,7 +9,7 @@
 #include "tools.h"
 #include "seqtools.h"
 
-#define DEBUG 1
+#define DEBUG 0
 
 long *idum;
 

--- a/mosaic_fb.c
+++ b/mosaic_fb.c
@@ -6,9 +6,9 @@
 #include "tools.h"
 #include "seqtools.h"
 #include "mosaic_fb.h"
+#include <stdlib.h>
 
 #define DEBUG 0
-
 
 main(int argc, char *argv[]) {
 
@@ -1619,11 +1619,15 @@ void kalign_vt(struct data *my_data, struct pars *my_pars, struct matrices *my_m
 	ofp = fopen(my_pars->alignment_file, "a");
 	fprintf(ofp,"\nTarget: %s\tLength: %i\tMLlk: %.3lf\n",my_data->seqs[target]->name, my_data->seqs[target]->length, my_matrices->llk);
 
+	const int printWidth = 30;
+	char formatString[100];
+	sprintf(formatString, "%%%ds\t", printWidth);
+
 	/*First print target sequence*/
 	cp++;
-	strncpy(tmp_name, my_data->seqs[target]->name, 15);
-	tmp_name[15]='\0';
-	fprintf(ofp,"%15s\t", tmp_name);
+	strncpy(tmp_name, my_data->seqs[target]->name, printWidth);
+	tmp_name[printWidth]='\0';
+	fprintf(ofp,formatString, tmp_name);
 	for (i=cp,pos_target=1;i<=2*my_matrices->maxl;i++) {
 		if (my_matrices->maxpath_state[i]==3) fprintf(ofp,"-");
 		else {
@@ -1635,7 +1639,7 @@ void kalign_vt(struct data *my_data, struct pars *my_pars, struct matrices *my_m
 	fflush(ofp);
 
 	/*Now do matching*/
-	for (i=1;i<=15;i++) fprintf(ofp," ");
+	for (i=1;i<=printWidth;i++) fprintf(ofp," ");
 	fprintf(ofp,"\t");
 	for (i=cp, pos_target=1;i<=2*my_matrices->maxl;i++) {
 		if (my_matrices->maxpath_state[i]==1) {
@@ -1653,16 +1657,17 @@ void kalign_vt(struct data *my_data, struct pars *my_pars, struct matrices *my_m
 	fflush(ofp);
 
 	/*Now do copy tracks - switch whenever gets to new value*/
-	strncpy(tmp_name, my_data->seqs[my_matrices->maxpath_copy[cp]]->name, 15);
-	tmp_name[15]='\0';
-	fprintf(ofp,"%15s\t",tmp_name);
+	strncpy(tmp_name, my_data->seqs[my_matrices->maxpath_copy[cp]]->name, printWidth);
+	tmp_name[printWidth]='\0';
+	fprintf(ofp,formatString,tmp_name);
 	for (i=cp;i<=2*my_matrices->maxl;i++) {
 
 		/*Check to see if need to make recombination event*/
 		if (i>cp && my_matrices->maxpath_copy[i]!=my_matrices->maxpath_copy[i-1]) {
-			strncpy(tmp_name, my_data->seqs[my_matrices->maxpath_copy[i]]->name, 15);
-			tmp_name[15]='\0';
-			fprintf(ofp,"\n%15s\t", tmp_name);
+			strncpy(tmp_name, my_data->seqs[my_matrices->maxpath_copy[i]]->name, printWidth);
+			tmp_name[printWidth]='\0';
+			fprintf(ofp, "\n");
+			fprintf(ofp, formatString, tmp_name);
 			for (j=1;j<=(i-cp);j++) fprintf(ofp," ");
 		}
 

--- a/mosaic_fb.c
+++ b/mosaic_fb.c
@@ -1739,11 +1739,9 @@ void kalign_vt(struct data *my_data, struct pars *my_pars, struct matrices *my_m
 				queryPosStart = my_matrices->maxpath_pos[i] - 1;
 			}
 			queryPosEnd = my_matrices->maxpath_pos[i] - 1;
-			fprintf(ofp, "%d,", my_matrices->maxpath_pos[i] - 1);
 		}
 	}
 
-	fprintf(ofp, "\n");
 	fprintf(ofp, formatString, tmp_name, queryPosStart, queryPosEnd);
 	fprintf(ofp, "%s", tmp_seq_string);
 	fprintf(ofp, "\n\n\n");

--- a/mosaic_fb.c
+++ b/mosaic_fb.c
@@ -8,6 +8,7 @@
 #include "mosaic_fb.h"
 #include <stdlib.h>
 #include <locale.h>
+#include <stdbool.h>
 
 #define DEBUG 0
 
@@ -30,7 +31,7 @@ int main(int argc, char *argv[]) {
 	if (argc==1 || argv[1]=="-h" || argv[1]=="-?") print_help(stdout);
 
 	my_pars = (struct pars *) get_pars(argc, argv);
-	my_data = read_fasta(my_pars, 0);  
+	my_data = read_fasta(my_pars, 0);
 
 	printf("\n\nRead %i sequences\n\n", my_data->nseq);
 	if (DEBUG) print_sequences(my_data, stdout);
@@ -78,7 +79,7 @@ int main(int argc, char *argv[]) {
 	}
 
 	/*If estimated parameters, add them to alignment file*/
-	if (my_pars->estimate==1 || my_pars->grid  || my_pars->verbose) {
+	if (my_pars->estimate==1 || my_pars->grid || my_pars->verbose) {
 		ofp = fopen(my_pars->alignment_file, ALIGNMENT_FILE_APPEND);
 		print_parameters(my_pars, ofp);
 		fclose(ofp);
@@ -125,9 +126,9 @@ void print_parameters(struct pars *my_pars, FILE *ofp) {
 	fprintf(ofp,"Parameters\n\n");
 	fprintf(ofp,"Gap initiation: %.5lf\n", my_pars->del);
 	fprintf(ofp,"Gap extension:  %.5lf\n", my_pars->eps);
-	fprintf(ofp,"Termination:    %.5lf\n", my_pars->term);
+	fprintf(ofp,"Termination:	%.5lf\n", my_pars->term);
 	fprintf(ofp,"Recombination:  %.5lf\n", my_pars->rho);
-	fprintf(ofp,"fMatch:         %.5lf\n", my_pars->piM);
+	fprintf(ofp,"fMatch:		 %.5lf\n", my_pars->piM);
 
 	fprintf(ofp,"\nState frequencies:\n");
 	for (i=0;i<my_pars->nstate;i++) fprintf(ofp,"%c\t%.5lf\n",num2nuc(i, my_pars->type), my_pars->si[i]);
@@ -206,6 +207,7 @@ struct pars * get_pars(int argc, char *argv[]) {
 	my_pars->rho_high=1e-1;
 	my_pars->log_scale=1;
 
+	my_pars->breakOnLowerSeqPos = false;
 
 	for (k=1; k<argc; k++) if (strchr(argv[k], '-')) {
 		
@@ -330,6 +332,10 @@ struct pars * get_pars(int argc, char *argv[]) {
 			my_pars->verbose=0;
 		}
 
+		if (strcmp(in_str, "-breakOnLowerSeqPos") == 0) {
+			my_pars->breakOnLowerSeqPos = true;
+		}
+
 	}
 
 
@@ -408,8 +414,8 @@ struct pars * get_pars(int argc, char *argv[]) {
 
 	}
 	else {
-		my_pars->posterior_file = strcat(my_pars->posterior_file,  "post.txt");
-		my_pars->alignment_file = strcat(my_pars->alignment_file,  "align.txt");
+		my_pars->posterior_file = strcat(my_pars->posterior_file, "post.txt");
+		my_pars->alignment_file = strcat(my_pars->alignment_file, "align.txt");
 		my_pars->llk_grid_file = strcat(my_pars->llk_grid_file, "grid.txt");
 	}
 
@@ -676,7 +682,7 @@ void kalign_fb(struct data *my_data, struct pars *my_pars, struct matrices *my_m
 
 			for (pos_seq=1;pos_seq<=l2;pos_seq++) {
 
-  				llk_r += (double) exp(backward_m[seq][pos_seq][pos_target+1]-max_r)*(my_pars->sm[s1[pos_target+1]][s2[pos_seq]])*(my_pars->piM);
+ 				llk_r += (double) exp(backward_m[seq][pos_seq][pos_target+1]-max_r)*(my_pars->sm[s1[pos_target+1]][s2[pos_seq]])*(my_pars->piM);
 				llk_r += (double) exp(backward_i[seq][pos_seq][pos_target+1]-max_r)*(my_pars->si[s1[pos_target+1]])*(my_pars->piI);
 			}
 		}
@@ -1066,7 +1072,7 @@ void print_max_acc_alignment(struct data *my_data, struct pars *my_pars, struct 
 			}
 		}
 
-		/*If from M then  look at marginal best and delete state*/
+		/*If from M then look at marginal best and delete state*/
 		else if (my_matrices->maxpath_state[cp]==1) {
 
 			for (seq=1, max_acc=0.0;seq<=my_data->nseq;seq++) if (my_matrices->who_copy[seq]) {
@@ -1141,7 +1147,7 @@ void print_max_acc_alignment(struct data *my_data, struct pars *my_pars, struct 
 	fflush(ofp);
 
 	/*Now do matching*/
-	fprintf(ofp,"          \t");
+	fprintf(ofp,"		  \t");
 	for (i=cp, pos_target=1;i<=2*my_matrices->maxl;i++) {
 		if (my_matrices->maxpath_state[i]==1) {
 			if (my_data->seqs[target]->seq[pos_target] == my_data->seqs[my_matrices->maxpath_copy[i]]->seq[my_matrices->maxpath_pos[i]]) fprintf(ofp,"|");
@@ -1670,10 +1676,14 @@ void kalign_vt(struct data *my_data, struct pars *my_pars, struct matrices *my_m
 		fprintf(ofp," ");
 	}
 	fprintf(ofp,"\t");
-	for (i=cp, pos_target=1;i<=2*my_matrices->maxl;i++) {
+	for (i=cp, pos_target=1; i <= 2*my_matrices->maxl; ++i) {
 		if (my_matrices->maxpath_state[i]==1) {
-			if (my_data->seqs[target]->seq[pos_target] == my_data->seqs[my_matrices->maxpath_copy[i]]->seq[my_matrices->maxpath_pos[i]]) fprintf(ofp,"|");
-			else fprintf(ofp," ");
+			if (my_data->seqs[target]->seq[pos_target] == my_data->seqs[my_matrices->maxpath_copy[i]]->seq[my_matrices->maxpath_pos[i]]) {
+				fprintf(ofp,"|");
+			}
+			else {
+				fprintf(ofp," ");
+			}
 			pos_target++;
 		}
 		else if (my_matrices->maxpath_state[i]==2) {
@@ -1692,10 +1702,11 @@ void kalign_vt(struct data *my_data, struct pars *my_pars, struct matrices *my_m
 	tmp_name[printWidth]='\0';
 	memset(tmp_seq_string, '\0', target_length);
 	tmp_seq_pos = 0;
-	for (i=cp; i <= 2*my_matrices->maxl ; ++i) {
+	for (i=cp; i <= 2*my_matrices->maxl; ++i) {
 
 		/*Check to see if need to make recombination event*/
-		if (i>cp && my_matrices->maxpath_copy[i] != my_matrices->maxpath_copy[i-1]) {
+		if ((i>cp && my_matrices->maxpath_copy[i] != my_matrices->maxpath_copy[i-1]) ||
+				(my_pars->breakOnLowerSeqPos && my_matrices->maxpath_pos[i] < my_matrices->maxpath_pos[i-1]) ) {
 
 			fprintf(ofp, formatString, tmp_name, queryPosStart, queryPosEnd);
 			fprintf(ofp, "%s", tmp_seq_string);
@@ -1705,10 +1716,10 @@ void kalign_vt(struct data *my_data, struct pars *my_pars, struct matrices *my_m
 			tmp_name[printWidth] = '\0';
 			tmp_seq_pos = 0;
 
-                	if (queryPosStart != queryPosEnd) {
-                	    queryPosStart = my_matrices->maxpath_pos[i] - 1;
-                	    queryPosEnd = my_matrices->maxpath_pos[i] - 1;
-                	}
+			if (queryPosStart != queryPosEnd) {
+				queryPosStart = my_matrices->maxpath_pos[i] - 1;
+				queryPosEnd = my_matrices->maxpath_pos[i] - 1;
+			}
 
 			for (j=1;j<=(i-cp);j++){
 				tmp_seq_string[tmp_seq_pos++] = ' ';
@@ -1724,13 +1735,15 @@ void kalign_vt(struct data *my_data, struct pars *my_pars, struct matrices *my_m
 			tmp_seq_string[tmp_seq_pos++] = num2nuc(my_data->seqs[my_matrices->maxpath_copy[i]]->seq[my_matrices->maxpath_pos[i]], my_data->type);
 			tmp_seq_string[tmp_seq_pos] = '\0';
 
-                	if (queryPosStart == -1) {
-                	    queryPosStart = my_matrices->maxpath_pos[i] - 1;
-                	}
-                	queryPosEnd = my_matrices->maxpath_pos[i] - 1;
+			if (queryPosStart == -1) {
+				queryPosStart = my_matrices->maxpath_pos[i] - 1;
+			}
+			queryPosEnd = my_matrices->maxpath_pos[i] - 1;
+			fprintf(ofp, "%d,", my_matrices->maxpath_pos[i] - 1);
 		}
 	}
 
+	fprintf(ofp, "\n");
 	fprintf(ofp, formatString, tmp_name, queryPosStart, queryPosEnd);
 	fprintf(ofp, "%s", tmp_seq_string);
 	fprintf(ofp, "\n\n\n");
@@ -2365,9 +2378,10 @@ void print_help(FILE *ofp) {
 	fprintf(ofp,"-tag <string>\t\tTag to attach to output files\n");
 	fprintf(ofp,"-group <int> <string1> <string2> ... \tNumber of groups to split data into and identifiers\n");
 	fprintf(ofp,"-target <string>\tGroup to analyse as target sequences\n");
-	fprintf(ofp,"-psum           \tPrint out summed posteriors for match states in each sequence\n");
+	fprintf(ofp,"-psum		   \tPrint out summed posteriors for match states in each sequence\n");
 	fprintf(ofp,"-estimate\t\tEstimate parameters by EM with Pr{rec}=0\n");
 	fprintf(ofp,"-grid <double> <double> <int> <flag> \tGrid for estimation of rho: values required are start, end, #pts and flag indicating whether on log scale\n");
+	fprintf(ofp,"-breakOnLowerSeqPos\tIf true, will split a sequence when the position of sequential bases in the alignment decreases\n");
 
 	fprintf(ofp,"\n\nAdditional options\n\n");
 /*	fprintf(ofp,"-e1\t\t\tFlag that sets emission probabilities to 1\n");*/

--- a/mosaic_fb.c
+++ b/mosaic_fb.c
@@ -1696,13 +1696,13 @@ void kalign_vt(struct data *my_data, struct pars *my_pars, struct matrices *my_m
 
 		/*Check to see if need to make recombination event*/
 		if (i>cp && my_matrices->maxpath_copy[i] != my_matrices->maxpath_copy[i-1]) {
-			strncpy(tmp_name, my_data->seqs[my_matrices->maxpath_copy[i]]->name, printWidth);
-			tmp_name[printWidth] = '\0';
 
 			fprintf(ofp, formatString, tmp_name, queryPosStart, queryPosEnd);
 			fprintf(ofp, "%s", tmp_seq_string);
 			fprintf(ofp, "\n");
-
+			
+			strncpy(tmp_name, my_data->seqs[my_matrices->maxpath_copy[i]]->name, printWidth);
+			tmp_name[printWidth] = '\0';
 			tmp_seq_pos = 0;
 
                 	if (queryPosStart != queryPosEnd) {

--- a/mosaic_fb.h
+++ b/mosaic_fb.h
@@ -24,6 +24,11 @@
 
 #define MIN_PROB 1e-32
 
+#define ALIGNMENT_FILE_WRITE "w"
+#define ALIGNMENT_FILE_APPEND "a"
+
+unsigned int gDISPLAY_WIDTH = 30;
+
 long *idum;
 
 		/*Amino acids - IUPAC convention

--- a/seqtools.c
+++ b/seqtools.c
@@ -267,15 +267,15 @@ char num2nuc(int i, int type) {
 
 	if (type == 1) {
 		if (i<0 || i>25) {
-			printf("\n\n***Error: cannot convert number to AA ***\n\n");
-			exit(0);
+			printf("\n\n***Error: cannot convert number to AA (%d)***\n\n", i);
+			exit(1);
 		}
 		return aa[i];
 	}
 	else {
 		if (i<0 || i>5) {
-			printf("\n\n***Error: cannot convert number to NT ***\n\n");
-			exit(0);
+			printf("\n\n***Error: cannot convert number to NT (%d)***\n\n", i);
+			exit(1);
 		}
 		return nuc[i];
 	}

--- a/seqtools.h
+++ b/seqtools.h
@@ -3,6 +3,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <stdbool.h>
 
 #define MAXNAME 1000
 #define MAXFILENAME 1000
@@ -121,6 +122,9 @@ struct pars {	/*keeps program parameters*/
 
 	/*Some global values to keep track of*/
 	double combined_llk;
+
+	// If true, will split a sequence when the position of sequential bases in the alignment decreases
+	bool breakOnLowerSeqPos; 
 
 };
 


### PR DESCRIPTION
Now the sequence names are fully displayed regardless of their length (as long as it is less than 1000 chars).
Now the target positions are output in the align.txt file in addition to the alignments themselves.