### PR TITLE
Ensure CLI-set parameters overrides param-file values

### DIFF
--- a/mosaic_fb.c
+++ b/mosaic_fb.c
@@ -175,6 +175,7 @@ struct pars * get_pars(int argc, char *argv[]) {
 	my_pars->rho=(double) DEFAULT_REC;
 	my_pars->term=(double) DEFAULT_TERM;
 	my_pars->pmatch = (double) DEFAULT_PMATCH;
+    unsigned int SET_PARAMS = 0;
 	my_pars->type = -1;
 
 	my_pars->input_filename = (char *) malloc((size_t) MAXFILENAME*sizeof(char));
@@ -281,18 +282,22 @@ struct pars * get_pars(int argc, char *argv[]) {
 
 		if (strcmp(in_str, "-rec") == 0) {
 			my_pars->rho = (double) atof(argv[k+1]);
+            SET_PARAMS |= REC_SET;
 		}
 
 		if (strcmp(in_str, "-del") == 0) {
 			my_pars->del = (double) atof(argv[k+1]);
+            SET_PARAMS |= DEL_SET;
 		}
 
 		if (strcmp(in_str, "-eps") == 0) {
 			my_pars->eps = (double) atof(argv[k+1]);
+            SET_PARAMS |= EPS_SET;
 		}
 
 		if (strcmp(in_str, "-term") == 0) {
 			my_pars->term = (double) atof(argv[k+1]);
+            SET_PARAMS |= TERM_SET;
 		}
 
 		if (strcmp(in_str, "-e1") == 0) {
@@ -352,7 +357,7 @@ struct pars * get_pars(int argc, char *argv[]) {
 			printf("\n\n***Error: cannot open file with input parameters ***\n\n");
 			exit(1);
 		}
-		read_params_from_file(my_pars, ifp);
+		read_params_from_file(my_pars, ifp, SET_PARAMS);
 		fclose(ifp);
 	}
 
@@ -2160,7 +2165,7 @@ void calculate_expected_values(struct data *my_data, struct pars *my_pars, struc
 
 /*To read parameters from input file*/
 
-void read_params_from_file(struct pars *my_pars, FILE *ifp){
+void read_params_from_file(struct pars *my_pars, FILE *ifp, unsigned int SET_PARAMS){
 
 	int i, j;
 	char *c, *line, **end_ptr;
@@ -2179,6 +2184,7 @@ void read_params_from_file(struct pars *my_pars, FILE *ifp){
 		if(!line) break;
 
 		if (c=strstr(line, "Gap initiation")) {
+            if (SET_PARAMS & DEL_SET) continue;
 			c = strchr(c, ':');
 			if (!c) {
 				printf("\n\n***Error: incorrect input format in parameter file ***\n\n");
@@ -2190,6 +2196,7 @@ void read_params_from_file(struct pars *my_pars, FILE *ifp){
 
 		}
 		else if (c=strstr(line, "Gap extension")) {
+            if (SET_PARAMS & EPS_SET) continue;
 			c = strchr(c, ':');
 			if (!c) {
 				printf("\n\n***Error: incorrect input format in parameter file ***\n\n");
@@ -2201,6 +2208,7 @@ void read_params_from_file(struct pars *my_pars, FILE *ifp){
 
 		}
 		else if (c=strstr(line, "Termination")) {
+            if (SET_PARAMS & TERM_SET) continue;
 			c = strchr(c, ':');
 			if (!c) {
 				printf("\n\n***Error: incorrect input format in parameter file ***\n\n");
@@ -2212,6 +2220,7 @@ void read_params_from_file(struct pars *my_pars, FILE *ifp){
 
 		}
 		else if (c=strstr(line, "Recombination")) {
+            if (SET_PARAMS & REC_SET) continue;
 			c = strchr(c, ':');
 			if (!c) {
 				printf("\n\n***Error: incorrect input format in parameter file ***\n\n");
@@ -2220,7 +2229,6 @@ void read_params_from_file(struct pars *my_pars, FILE *ifp){
 			c++;
 			my_pars->rho = (double) strtod(c, end_ptr);
 			if (my_pars->rho<=MIN_PROB) my_pars->rho = MIN_PROB;
-;
 		}
 
 		else if(c=strstr(line, "State frequencies")) {
@@ -2367,7 +2375,7 @@ void print_help(FILE *ofp) {
 	fprintf(ofp,"-seq <file>\t\tName of file containing sequences in FASTA format\n");
 
 	fprintf(ofp,"\n\nOptional parameters\n\n");
-	fprintf(ofp,"-params <file>\tName of file containing input parameters\n");
+	fprintf(ofp,"-params <file>\t\tName of file containing input parameters. Note manually set parameters (e.g. -rec) will override values in this file\n");
 	fprintf(ofp,"-rec <double>\t\tRecombination probability (default = %.4lf)\n", (double) DEFAULT_REC);
 	fprintf(ofp,"-del <double>\t\tRate of moving to delete state (default = %.3lf)\n", (double) DEFAULT_DEL);
 	fprintf(ofp,"-eps <double>\t\tRate of extending in delete/insert state (default = %.3lf)\n", (double) DEFAULT_EPS);

--- a/mosaic_fb.h
+++ b/mosaic_fb.h
@@ -18,6 +18,10 @@
 #define DEFAULT_TERM 0.001
 #define DEFAULT_PMATCH 0.0
 #define DEFAULT_PIM 0.75
+#define REC_SET 1
+#define DEL_SET 2
+#define EPS_SET 4
+#define TERM_SET 8
 
 #define LLK_TOL 0.01
 #define MAX_IT_EM 10
@@ -167,7 +171,8 @@ void kalign_vt(struct data *my_data, struct pars *my_pars, struct matrices *my_m
 void estimate_parameters_em_no_rec(struct data *my_data, struct pars *my_pars, struct matrices *my_matrices);
 void kalign_fb_no_rec(struct data *my_data, struct pars *my_pars, struct matrices *my_matrices, int target);
 void calculate_expected_values(struct data *my_data, struct pars *my_pars, struct matrices *my_matrices, int target);
-void read_params_from_file(struct pars *my_pars, FILE *ifp);
+void read_params_from_file(struct pars *my_pars, FILE *ifp,
+                           unsigned int SET_PARAMS);
 void print_help(FILE *ofp);
 void print_parameters(struct pars *my_pars, FILE *ofp);
 void calculate_llk_over_rho_grid(struct data *my_data, struct pars *my_pars, struct matrices *my_matrices);


### PR DESCRIPTION
Hello! 

A simple proposed change: if you specify both `-params` and manual parameter values (e.g. `-rec`), on CLI, prior to this PR the manually set param got ignored. Not this makes sure it is used.

I needed this when estimating the `-rec` parameter by trying out many values, with a fixed, previously estimated set of other `-params` (transition matrix, gap open/extend..)